### PR TITLE
Create char_array_extents.cpp

### DIFF
--- a/char_array_extents.cpp
+++ b/char_array_extents.cpp
@@ -1,0 +1,23 @@
+#include <type_traits>
+#include <utility>
+
+template <typename T> 
+constexpr auto StringProxy()
+{
+  struct SP
+  {
+      char str[std::rank_v<T>];
+      constexpr bool operator==(char const* cp)
+      {
+          for (unsigned i=0; i!=std::rank_v<T> && str[i]==*cp; ++i, ++cp);
+          return !*cp;
+      }
+  };
+  return []<std::size_t... i>(std::index_sequence<i...>){
+    return SP{char(std::extent_v<T,i>)...};
+  }(std::make_index_sequence<std::rank_v<T>>{});
+}
+
+static_assert(StringProxy<char['S']['t']['r']['i']['n']['g']>() == "String", "");
+                                                           
+int main() { return 0; }

--- a/char_array_extents.cpp
+++ b/char_array_extents.cpp
@@ -9,7 +9,8 @@ constexpr auto StringProxy()
       char str[std::rank_v<T>];
       constexpr bool operator==(char const* cp)
       {
-          for (unsigned i=0; i!=std::rank_v<T> && str[i]==*cp; ++i, ++cp);
+          for (unsigned i=0; i!=std::rank_v<T> && (str[i]==*cp || !*cp); ++i, ++cp)
+              if (!*cp) return false;
           return !*cp;
       }
   };

--- a/function_array_extents.cpp
+++ b/function_array_extents.cpp
@@ -1,0 +1,40 @@
+template <typename T> 
+constexpr auto StringProxy()
+{
+  struct proxy
+  {
+    constexpr bool operator==(char const* s)
+    {
+      T* scmp = []<char... c>(char const* s,
+                              void(*)(char (&...a)[c]))
+      {
+          return ((*s++==c) && ...) && !*s;
+      };
+      return (*scmp)(s,0);
+    }
+  };
+  return proxy{};
+}
+
+static_assert(
+StringProxy<
+  bool(
+    char const *,
+    void(*)(
+      char (&)['S'],
+      char (&)['t'],
+      char (&)['r'],
+      char (&)['i'],
+      char (&)['n'],
+      char (&)['g'],
+      char (&)['P'],
+      char (&)['r'],
+      char (&)['o'],
+      char (&)['x'],
+      char (&)['y']
+
+    )
+  )
+>() == "StringProxy", "");
+                                                           
+int main() { return 0; }

--- a/not_so_pretty.cpp
+++ b/not_so_pretty.cpp
@@ -1,0 +1,27 @@
+template <typename T> 
+constexpr auto StringProxy()
+{
+  constexpr auto const& pf = __PRETTY_FUNCTION__;
+  constexpr auto prefix = sizeof("constexpr auto StringProxy() [with T =");
+  constexpr auto size = sizeof(pf) - (prefix + 2);
+
+  struct SP
+  {
+      char str[size];
+      constexpr bool operator==(char const* cp)
+      {
+          for (unsigned i=0; i!=size && (str[i]==*cp || !*cp); ++i, ++cp)
+              if (!*cp) return false;
+          return !*cp;
+      }
+  };
+
+  SP ret{};
+  for (unsigned i = 0; i != size; ++i)
+      ret.str[i] = pf[prefix+i];
+  return ret;
+}
+
+static_assert(StringProxy<struct StringProxy>() == "StringProxy", "");
+
+int main() { return 0; }

--- a/recursive_function_array_extents.cpp
+++ b/recursive_function_array_extents.cpp
@@ -5,12 +5,10 @@ constexpr auto StringProxy()
   {
     constexpr bool operator==(char const* s)
     {
-      constexpr auto str_cmp = [](char const* cp) -> bool
-      {
         using R = decltype(T{}({}));
 
         if constexpr (sizeof(R) == 1)
-            return !*cp;
+            return !*s;
         else
         {
           T chr_cmp = [](auto const& a)
@@ -18,12 +16,10 @@ constexpr auto StringProxy()
             if (a[0] == char{sizeof(a)})
                 return R{};
             else
-                return R{[](auto const&) -> decltype(R{}({})){ return{}; }};
+                return R{[](auto const&)->decltype(R{}({})){return{};}};
           };
-          return chr_cmp({*cp})==R{} && StringProxy<R>()==cp+1;
+          return chr_cmp({*s})==R{} && StringProxy<R>()==s+1;
         }
-      };
-      return str_cmp(s);
     }
   };
   return proxy{};

--- a/recursive_function_array_extents.cpp
+++ b/recursive_function_array_extents.cpp
@@ -1,0 +1,61 @@
+template <typename T> 
+constexpr auto StringProxy()
+{
+  struct proxy
+  {
+    constexpr bool operator==(char const* s)
+    {
+      constexpr auto str_cmp = [](char const* cp) -> bool
+      {
+        using R = decltype(T{}({}));
+
+        constexpr T chr_cmp = [](auto const& a)
+        {
+          if (a[0] == char{sizeof(a) & 0xFF})
+              return R{nullptr};
+          else
+              return R{[](auto const&)
+                       ->decltype(R{}({})){return{};}};
+        };
+    
+        if (chr_cmp({*cp}) == R{nullptr})
+            return StringProxy<R>() == cp+1;
+        else
+            return false;
+      };
+      return str_cmp(s);
+    }
+  };
+  return proxy{};
+}
+
+// Bending the rules with a specialization to terminate recursion
+template <> 
+constexpr auto StringProxy<void*(*)(char const(&)[0x100])>() // EOS
+{
+  struct proxy
+  {
+    constexpr bool operator==(char const* s) { return *s=='\0'; }
+  };
+  return proxy{};
+}
+
+static_assert(
+  StringProxy
+  <
+    auto(*)(char const(&)['S'])->
+    auto(*)(char const(&)['t'])->
+    auto(*)(char const(&)['r'])->
+    auto(*)(char const(&)['i'])->
+    auto(*)(char const(&)['n'])->
+    auto(*)(char const(&)['g'])->
+    auto(*)(char const(&)['P'])->
+    auto(*)(char const(&)['r'])->
+    auto(*)(char const(&)['o'])->
+    auto(*)(char const(&)['x'])->
+    auto(*)(char const(&)['y'])->
+    void*(*)(char const(&)[0x100]) // EOS
+  >
+   () == "StringProxy", "");
+
+int main() { return 0; }


### PR DESCRIPTION
https://wandbox.org/permlink/5aVvo78zl2w0nYIl
Not the answer you're looking for, and disqualifies itself for using includes.
Also, it can't compile for strings as large as "StringProxy" because the resulting char array type is too large
(even though it is never instantiated)